### PR TITLE
MockInteractions has moved to a better place

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,18 +17,17 @@
   },
   "license": "MIT",
   "homepage": "https://github.com/PolymerElements/paper-radio-button",
-  "ignore": [
-  ],
+  "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#v0.8.0-rc.6",
-    "layout": "Polymer/layout#master",
-    "paper-ripple": "Polymer/paper-ripple#0.8-preview",
+    "paper-ripple": "PolymerElements/paper-ripple#^0.8.0",
     "paper-styles": "PolymerLabs/paper-styles#^0.8.0"
   },
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#~0.6.1",
     "web-component-tester": "Polymer/web-component-tester#^2.2.3",
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^0.8.0",
-    "test-fixture": "PolymerElements/test-fixture#^0.8.0"
+    "test-fixture": "PolymerElements/test-fixture#^0.8.0",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^0.8.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="apple-mobile-web-app-capable" content="yes">
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../../layout/layout.html">
+  <link rel="import" href="../../paper-styles/layout.html">
   <link rel="import" href="../paper-radio-button.html">
 
   <link rel="stylesheet" href="../../paper-styles/demo.css">

--- a/index.html
+++ b/index.html
@@ -20,16 +20,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../polymer/polymer.html">
   <link rel="import" href="../iron-doc-viewer/iron-doc-viewer.html">
 
-  <style>
-    body {
-      margin: 16px;
-    }
-  </style>
-
 </head>
 <body>
 
-  <iron-doc-viewer src="paper-radio-button.html"></iron-doc-viewer>
+  <iron-doc-viewer></iron-doc-viewer>
 
 </body>
 </html>

--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -39,7 +39,7 @@ Styling a radio button:
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
-<link rel="import" href="../paper-styles/x-theme.html">
+<link rel="import" href="../paper-styles/default-theme.html">
 
 /* TODO: This needs to use core-focusable when it's ready. */
 <dom-module id="paper-radio-button">

--- a/test/basic.html
+++ b/test/basic.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
-  <script src="../../core-focusable/test/test-helpers.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../paper-radio-button.html">
@@ -39,11 +39,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     suite('defaults', function() {
       var r1;
-      var r2;
 
       setup(function() {
         r1 = fixture('NoLabel');
-        r2 = fixture('WithLabel');
       });
 
       test('check button via click', function() {
@@ -84,7 +82,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         r1 = fixture('NoLabel');
         r2 = fixture('WithLabel');
       });
-      
+
       test('has aria role "radio"', function() {
         assert.isTrue(r1.getAttribute('role') == 'radio');
         assert.isTrue(r2.getAttribute('role') == 'radio');


### PR DESCRIPTION
From core-focusable to iron-test-helpers. I've also:
- cleaned up the `paper-ripple` and `layout` deps in `bower.json`
- caught up with the updates in `iron-doc-viewer`
