### PR TITLE
Clean up isToggle vs toggles misunderstanding

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -49,23 +49,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </section>
 
   <section>
-    <div class="label">Radio button (toggles)</div>
-    <paper-radio-button toggles></paper-radio-button>
-  </section>
-
-  <section>
     <div class="label">Radio button (disabled)</div>
     <paper-radio-button disabled></paper-radio-button>
   </section>
 
   <section>
     <div class="label">Radio button (checked, disabled)</div>
-    <paper-radio-button checked disabled toggles></paper-radio-button>
+    <paper-radio-button checked disabled></paper-radio-button>
   </section>
 
   <section>
-    <div class="label">Radio button (toggles, red to blue)</div>
-    <paper-radio-button class="blue" toggles></paper-radio-button>
+    <div class="label">Radio button (toggles red to blue)</div>
+    <paper-radio-button class="blue"></paper-radio-button>
   </section>
 </body>
 </html>

--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -110,6 +110,20 @@ Styling a radio button:
         value: false,
         reflectToAttribute: true,
         observer: '_checkedChanged'
+      },
+
+      /**
+       * If true, the button toggles the active state with each tap or press
+       * of the spacebar.
+       *
+       * @attribute toggles
+       * @type boolean
+       * @default true
+       */
+      toggles: {
+        type: Boolean,
+        value: true,
+        reflectToAttribute: true
       }
     },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="WithLabel">
     <template>
-      <paper-radio-button id="radio2" toggles>Batman</paper-radio-button>
+      <paper-radio-button id="radio2">Batman</paper-radio-button>
     </template>
   </test-fixture>
 


### PR DESCRIPTION
The old radio-button had a weird behaviour where you could toggle it but never untoggle it. This behaviour belongs in the `paper-radio-group` not the button itself.

/cc @morethanreal @cdata 
