### PR TITLE
fix theme colours

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,6 +27,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       --paper-radio-button-checked-color: #4285f4;
       --paper-radio-button-checked-ink-color: #4285f4;
+
+      --paper-radio-button-label-color: #009987;
     }
 
     .label {
@@ -43,23 +45,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <section>
     <div class="label">Radio button</div>
     <paper-radio-button></paper-radio-button>
+    <paper-radio-button checked></paper-radio-button>
+    <paper-radio-button disabled></paper-radio-button>
+    <paper-radio-button checked disabled></paper-radio-button>
+
     <br>
     <paper-radio-button>Radio button with label</paper-radio-button>
-  </section>
-
-  <section>
-    <div class="label">Radio button (disabled)</div>
-    <paper-radio-button disabled></paper-radio-button>
-  </section>
-
-  <section>
-    <div class="label">Radio button (checked, disabled)</div>
-    <paper-radio-button checked disabled></paper-radio-button>
-  </section>
-
-  <section>
-    <div class="label">Radio button (toggles red to blue)</div>
-    <paper-radio-button class="blue"></paper-radio-button>
+    <br>
+    <paper-radio-button disabled>Disabled button with label</paper-radio-button>
+    <br>
+    <paper-radio-button class="blue">Extremely colourful button</paper-radio-button>
   </section>
 </body>
 </html>

--- a/paper-radio-button.css
+++ b/paper-radio-button.css
@@ -32,6 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   width: 48px;
   height: 48px;
   color: var(--paper-radio-button-unchecked-ink-color);
+  opacity: 0.6;
 }
 
 :host #ink[checked] {
@@ -80,6 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   margin-left: 10px;
   white-space: normal;
   pointer-events: none;
+  color: var(--paper-radio-button-label-color);
 }
 
 #radioLabel[hidden] {
@@ -91,15 +93,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   pointer-events: none;
 }
 
-:host([disabled]) #offRadio,
-:host([disabled]) #onRadio {
-  opacity: 0.33;
-}
-
 :host([disabled]) #offRadio {
   border-color: var(--paper-radio-button-unchecked-color);
+  opacity: 0.5;
 }
 
 :host([disabled][checked]) #onRadio {
   background-color: var(--paper-radio-button-unchecked-color);
+  opacity: 0.5;
+}
+
+:host([disabled]) #radioLabel {
+  /* slightly darker than the button, so that it's readable */
+  opacity: 0.65;
 }

--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -35,6 +35,9 @@ Styling a radio button:
     /* Checked state colors. */
     --paper-radio-button-checked-color: #009688;
     --paper-radio-button-checked-ink-color: #0f9d58;
+
+    /* Label color. */
+    --paper-radio-button-label-color: #009987;
   }
 </style>
 
@@ -49,6 +52,8 @@ Styling a radio button:
 
     --paper-radio-button-checked-color: var(--default-primary-color);
     --paper-radio-button-checked-ink-color: var(--default-primary-color);
+
+    --paper-radio-button-label-color: var(--primary-text-color);
   }
 </style>
 
@@ -134,6 +139,9 @@ Styling a radio button:
       },
 
       _buttonStateChanged: function() {
+        if (this.disabled) {
+          return;
+        }
         this.checked = this.active;
       },
 
@@ -144,5 +152,5 @@ Styling a radio button:
       }
     })
   </script>
-  
+
 </dom-module>


### PR DESCRIPTION
- makes colours more accessible (https://github.com/PolymerElements/paper-radio-button/issues/15)
- decreases the ripple opacity (https://github.com/PolymerElements/paper-radio-button/issues/16)
- disabled and checked buttons didn't work, and now they do
- added a custom property for the label colour

/cc @cdata 
