### PR TITLE
Ripple should always be centered

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 User can tap the radio button to check it.  But it cannot be unchecked by
 tapping once checked.
 
-Use `paper-radio-group` to group a set of radio buttons.  When radio buttons
+Use `paper-radio-group` to group a set of radio buttons. When radio buttons
 are inside a radio group, only one radio button in the group can be checked.
 
 Example:
@@ -16,7 +16,7 @@ Styling a radio button:
 
 ```html
 <style is="custom-style">
-  * {
+  :root {
     /* Unchecked state colors. */
     --paper-radio-button-unchecked-color: #5a5a5a;
     --paper-radio-button-unchecked-ink-color: #5a5a5a;

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/PolymerElements/paper-radio-button",
   "ignore": [],
   "dependencies": {
-    "paper-ripple": "PolymerElements/paper-ripple#^0.9.0",
+    "paper-ripple": "PolymerElements/paper-ripple#^0.9.2",
     "paper-styles": "PolymerLabs/paper-styles#^0.9.0",
     "paper-behaviors": "PolymerElements/paper-behaviors#^0.9.0",
     "polymer": "Polymer/polymer#^0.9.0"

--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -27,7 +27,7 @@ Example:
 Styling a radio button:
 
 <style is="custom-style">
-  * {
+  :root {
     /* Unhecked state colors. */
     --paper-radio-button-unchecked-color: #5a5a5a;
     --paper-radio-button-unchecked-ink-color: #5a5a5a;
@@ -102,10 +102,6 @@ Styling a radio button:
 
         /**
          * Gets or sets the state, `true` is checked and `false` is unchecked.
-         *
-         * @attribute checked
-         * @type boolean
-         * @default false
          */
         checked: {
           type: Boolean,
@@ -118,10 +114,6 @@ Styling a radio button:
         /**
          * If true, the button toggles the active state with each tap or press
          * of the spacebar.
-         *
-         * @attribute toggles
-         * @type boolean
-         * @default true
          */
         toggles: {
           type: Boolean,

--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -66,7 +66,7 @@ Styling a radio button:
     <div id="radioContainer">
       <div id="offRadio"></div>
       <div id="onRadio"></div>
-      <paper-ripple id="ink" class="circle" recenters checked$="[[checked]]"></paper-ripple>
+      <paper-ripple id="ink" class="circle" center checked$="[[checked]]"></paper-ripple>
     </div>
 
     <div id="radioLabel" aria-hidden="true"><content></content></div>


### PR DESCRIPTION
**material design spec audit - few changes needed https://github.com/PolymerElements/paper-radio-button/issues/16**
- Ripple should always be centered, regardless of where click or tap starts. That way it doesn't get clipped.

cc @notwaldorf @cdata @morethanreal 
