### PR TITLE
add more custom properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Styling a radio button:
   :root {
     /* Unchecked state colors. */
     --paper-radio-button-unchecked-color: #5a5a5a;
+    --paper-radio-button-unchecked-background-color: #fff;
     --paper-radio-button-unchecked-ink-color: #5a5a5a;
 
     /* Checked state colors. */

--- a/paper-radio-button.css
+++ b/paper-radio-button.css
@@ -47,6 +47,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   height: 12px;
   border-radius: 50%;
   border: solid 2px;
+  background-color: var(--paper-radio-button-unchecked-background-color, transparent);
   border-color: var(--paper-radio-button-unchecked-color, --primary-text-color);
   transition: border-color 0.28s;
 }

--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -31,6 +31,7 @@ The following custom properties and mixins are available for styling:
 
 Custom property | Description | Default
 ----------------|-------------|----------
+`--paper-radio-button-unchecked-background-color` | Radio button background color when the input is not checked | `transparent`
 `--paper-radio-button-unchecked-color` | Radio button color when the input is not checked | `--primary-text-color`
 `--paper-radio-button-unchecked-ink-color` | Selected/focus ripple color when the input is not checked | `--primary-text-color`
 `--paper-radio-button-checked-color` | Radio button color when the input is checked | `--default-primary-color`


### PR DESCRIPTION
Since we added a similar one to checkbox in https://github.com/PolymerElements/paper-checkbox/pull/35, I feel it couldn't hurt to add it here as well.

Having the radio colour different than the border colour, however, can be pretty ugly, and I feel we maybe shouldn't encourage that 😊. Sample:
![screen shot 2015-06-17 at 3 29 07 pm](https://cloud.githubusercontent.com/assets/1369170/8220245/af2c51e0-1505-11e5-8de8-103e8e53efe7.png)
