### PR TITLE
Fix handling of paper-radio focus.

### DIFF
--- a/paper-radio-button.css
+++ b/paper-radio-button.css
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 :host {
   display: inline-block;
   white-space: nowrap;
+  cursor: pointer;
 }
 
 :host(:focus) {
@@ -21,7 +22,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   position: relative;
   width: 16px;
   height: 16px;
-  cursor: pointer;
   vertical-align: middle;
 }
 
@@ -92,6 +92,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 /* disabled state */
 :host([disabled]) {
   pointer-events: none;
+  cursor: default;
 }
 
 :host([disabled]) #offRadio {

--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -71,7 +71,7 @@ Custom property | Description | Default
       hostAttributes: {
         role: 'radio',
         'aria-checked': false,
-        tabindex: 0
+        tabindex: -1
       },
 
       properties: {
@@ -130,6 +130,7 @@ Custom property | Description | Default
       _checkedChanged: function() {
         this.setAttribute('aria-checked', this.checked ? 'true' : 'false');
         this.active = this.checked;
+        this.setAttribute('tabindex', this.active ? 0 : -1);
         this.fire('iron-change');
       }
     })


### PR DESCRIPTION
Normal HTML radio buttons work differently from other focusable
HTML elements.  Only the selected radio button can be reached
using tab.

Additionally fix the stylesheet so the cursor is set for whole
element including the label.

I've created a simple page that shows the default behaviour of HTML radio buttons - http://jsfiddle.net/vdpo00f2/.
