### PR TITLE
remove ripple pointer events

### DIFF
--- a/paper-radio-button.css
+++ b/paper-radio-button.css
@@ -33,6 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   height: 48px;
   color: var(--paper-radio-button-unchecked-ink-color, --primary-text-color);
   opacity: 0.6;
+  pointer-events: none;
 }
 
 :host #ink[checked] {


### PR DESCRIPTION
Otherwise if `paper-radio-buttons` are too close, the ripple hijacks the click and you mis-select.
