### PR TITLE
fix aria label and dynamic creation

### DIFF
--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -109,11 +109,14 @@ Custom property | Description | Default
         }
       },
 
-      ready: function() {
-        if (Polymer.dom(this).textContent == '') {
+      attached: function() {
+        var trimmedText = Polymer.dom(this).textContent.trim();
+        if (trimmedText === '') {
           this.$.radioLabel.hidden = true;
-        } else {
-          this.setAttribute('aria-label', Polymer.dom(this).textContent);
+        }
+        // Don't stomp over a user-set aria-label.
+        if (trimmedText !== '' && !this.getAttribute('aria-label')) {
+          this.setAttribute('aria-label', trimmedText);
         }
         this._isReady = true;
       },

--- a/test/basic.html
+++ b/test/basic.html
@@ -36,6 +36,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="AriaLabel">
+    <template>
+      <paper-radio-button aria-label="Batman">Robin</paper-radio-button>
+    </template>
+  </test-fixture>
+
   <script>
     suite('defaults', function() {
       var r1;
@@ -94,6 +100,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('button with a label sets an aria label', function() {
         assert.isTrue(r2.getAttribute('aria-label') == "Batman");
+      });
+
+      test('button respects the user set aria-label', function() {
+        var c = fixture('AriaLabel');
+        assert.isTrue(c.getAttribute('aria-label') == "Batman");
       });
     });
   </script>


### PR DESCRIPTION
This is the same fix as in https://github.com/PolymerElements/paper-checkbox/pull/48
- Fixes the parallel bug to https://github.com/PolymerElements/paper-checkbox/pull/32 -- `textContent` was a little misunderstood, and will contain any whitespace between the `>` and the `</paper-radio-button>` which means the line `textContent == ''` is very rarely true.
- Fixes #26, where dynamically creating checkboxes was broken. This is still broken, but not as much, and will be fixed again when we can listen to changes in `<content>` (which is the correct solution)

@cdata PTAL
