### PR TITLE
be rtl friendly

### DIFF
--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -40,6 +40,7 @@ Custom property | Description | Default
 `--paper-radio-button-checked-color` | Radio button color when the input is checked | `--default-primary-color`
 `--paper-radio-button-checked-ink-color` | Selected/focus ripple color when the input is checked | `--default-primary-color`
 `--paper-radio-button-label-color` | Label color | `--primary-text-color`
+`--paper-radio-button-label-spacing` | Spacing between the label and the button | `10px`
 
 @group Paper Elements
 @element paper-radio-button
@@ -68,7 +69,7 @@ Custom property | Description | Default
         vertical-align: middle;
       }
 
-      :host #ink {
+      #ink {
         position: absolute;
         top: -16px;
         left: -16px;
@@ -79,15 +80,21 @@ Custom property | Description | Default
         pointer-events: none;
       }
 
-      :host #ink[checked] {
+      :host-context([dir="rtl"]) #ink {
+        right: -15px;
+        left: auto;
+      }
+
+      #ink[checked] {
         color: var(--paper-radio-button-checked-ink-color, --default-primary-color);
       }
 
-      :host #offRadio {
+      #offRadio {
         position: absolute;
         box-sizing: content-box;
         top: 0px;
         left: 0px;
+        right: 0px;
         width: 12px;
         height: 12px;
         border-radius: 50%;
@@ -97,11 +104,12 @@ Custom property | Description | Default
         transition: border-color 0.28s;
       }
 
-      :host #onRadio {
+      #onRadio {
         position: absolute;
         box-sizing: content-box;
         top: 4px;
         left: 4px;
+        right: 4px;
         width: 8px;
         height: 8px;
         border-radius: 50%;
@@ -125,10 +133,15 @@ Custom property | Description | Default
         position: relative;
         display: inline-block;
         vertical-align: middle;
-        margin-left: 10px;
+        margin-left: var(--paper-radio-button-label-spacing, 10px);
         white-space: normal;
         pointer-events: none;
         color: var(--paper-radio-button-label-color, --primary-text-color);
+      }
+
+      :host-context([dir="rtl"]) #radioLabel {
+        margin-left: 0px;
+        margin-right: var(--paper-radio-button-label-spacing, 10px);
       }
 
       #radioLabel[hidden] {


### PR DESCRIPTION
Fixes #30 :tada: Also:
- removed some useless `:host` that weren't needed
- fixed https://github.com/PolymerElements/paper-radio-button/issues/47 by adding a custom property for the label spacing

Using `<html dir="rtl">`
<img width="839" alt="screen shot 2015-10-14 at 9 09 52 am" src="https://cloud.githubusercontent.com/assets/1369170/10489848/80e1db24-7253-11e5-9353-38eb9148225e.png">

Using parent div with `dir="rtl"`:
<img width="265" alt="screen shot 2015-10-14 at 9 09 25 am" src="https://cloud.githubusercontent.com/assets/1369170/10489857/893a9fd6-7253-11e5-913c-c70d65f552d2.png">

Using `<paper-radio-button dir="rtl">`
<img width="273" alt="screen shot 2015-10-14 at 9 09 04 am" src="https://cloud.githubusercontent.com/assets/1369170/10489865/909f091a-7253-11e5-830a-b66f5b361b2d.png">
