### PR TITLE
label should also have a hand cursor

### DIFF
--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -54,6 +54,7 @@ Custom property | Description | Default
       :host {
         display: inline-block;
         white-space: nowrap;
+        cursor: pointer;
       }
 
       :host(:focus) {
@@ -65,7 +66,6 @@ Custom property | Description | Default
         position: relative;
         width: 16px;
         height: 16px;
-        cursor: pointer;
         vertical-align: middle;
       }
 


### PR DESCRIPTION
Since both the radio button and the label are clickable, it makes sense that both should get a hand cursor (vs hand cursor for the button and arrow for the label)
