### PR TITLE
fix regression

### DIFF
--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -68,6 +68,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       #radioContainer {
+        display: inline-block;
         @apply(--layout-inline);
         @apply(--layout-center-center);
         position: relative;
@@ -116,7 +117,12 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       #onRadio {
-        box-sizing: content-box;
+        box-sizing: border-box;
+        position: absolute;
+        top: calc(var(--calculated-paper-radio-button-size) / 4);
+        left: calc(var(--calculated-paper-radio-button-size) / 4);
+        right: calc(var(--calculated-paper-radio-button-size) / 4);
+        bottom: calc(var(--calculated-paper-radio-button-size) / 4);
         width: 50%;
         height: 50%;
         border-radius: 50%;


### PR DESCRIPTION
We introduced a regression in https://github.com/PolymerElements/paper-radio-button/pull/76/files where everything looked fine in the demo (possibly because of inherited styles), but in a plain world, the button looked like:

<img width="136" alt="screen shot 2016-02-02 at 2 18 16 pm" src="https://cloud.githubusercontent.com/assets/1369170/12766664/ab451bac-c9b9-11e5-993a-4ee108cea199.png">

This PR returns it to look less like a zombie
<img width="154" alt="screen shot 2016-02-02 at 2 28 26 pm" src="https://cloud.githubusercontent.com/assets/1369170/12766668/afe026a2-c9b9-11e5-8465-85661257e82d.png">
