### PR TITLE
Remove unneeded paper-ripple import

### DIFF
--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -10,7 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-behaviors/paper-checked-element-behavior.html">
-<link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 
 <!--


### PR DESCRIPTION
The `paper-behaviors/paper-checked-element-behavior.html` already import the `paper-ripple`.
