### PR TITLE
Remove paper-ripple from bower.json dependencies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "iron-checked-element-behavior": "PolymerElements/iron-checked-element-behavior#^1.0.0",
     "paper-behaviors": "PolymerElements/paper-behaviors#^1.0.0",
-    "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.1.0",
     "polymer": "Polymer/polymer#^1.1.0"
   },


### PR DESCRIPTION
Forgot to request this in #85.
