### PR TITLE
Added mixin to control size of radio button

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
   "ignore": [],
   "dependencies": {
     "iron-checked-element-behavior": "PolymerElements/iron-checked-element-behavior#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#~1.3.0",
     "paper-behaviors": "PolymerElements/paper-behaviors#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.1.0",
     "polymer": "Polymer/polymer#^1.1.0"

--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -11,6 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-behaviors/paper-checked-element-behavior.html">
 <link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 
 <!--
 Material design: [Radio button](https://www.google.com/design/spec/components/selection-controls.html#selection-controls-radio-button)
@@ -38,6 +39,7 @@ Custom property | Description | Default
 `--paper-radio-button-unchecked-ink-color` | Selected/focus ripple color when the input is not checked | `--primary-text-color`
 `--paper-radio-button-checked-color` | Radio button color when the input is checked | `--primary-color`
 `--paper-radio-button-checked-ink-color` | Selected/focus ripple color when the input is checked | `--primary-color`
+`--paper-radio-button-size` | Size of the radio button | `16px`
 `--paper-radio-button-label-color` | Label color | `--primary-text-color`
 `--paper-radio-button-label-spacing` | Spacing between the label and the button | `10px`
 
@@ -55,9 +57,11 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
     <style>
       :host {
         display: inline-block;
+        line-height: 0;
         white-space: nowrap;
         cursor: pointer;
         @apply(--paper-font-common-base);
+        --calculated-paper-radio-button-size: var(--paper-radio-button-size, 16px);
       }
 
       :host(:focus) {
@@ -65,27 +69,26 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       #radioContainer {
-        display: inline-block;
+        @apply(--layout-inline);
+        @apply(--layout-center-center);
         position: relative;
-        width: 16px;
-        height: 16px;
+        width: var(--calculated-paper-radio-button-size);
+        height: var(--calculated-paper-radio-button-size);
         vertical-align: middle;
       }
 
       #ink {
         position: absolute;
-        top: -16px;
-        left: -16px;
-        width: 48px;
-        height: 48px;
+        top: 50%;
+        left: 50%;
+        right: auto;
+        width: calc(3 * var(--calculated-paper-radio-button-size));
+        height: calc(3 * var(--calculated-paper-radio-button-size));
         color: var(--paper-radio-button-unchecked-ink-color, --primary-text-color);
         opacity: 0.6;
         pointer-events: none;
-      }
-
-      :host-context([dir="rtl"]) #ink {
-        right: -15px;
-        left: auto;
+        -webkit-transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%);
       }
 
       #ink[checked] {
@@ -94,12 +97,12 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
       #offRadio {
         position: absolute;
-        box-sizing: content-box;
-        top: 0px;
-        left: 0px;
-        right: 0px;
-        width: 12px;
-        height: 12px;
+        box-sizing: border-box;
+        top: 0;
+        left: 0;
+        right: 0;
+        width: 100%;
+        height: 100%;
         border-radius: 50%;
         border: solid 2px;
         background-color: var(--paper-radio-button-unchecked-background-color, transparent);
@@ -108,13 +111,9 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       #onRadio {
-        position: absolute;
         box-sizing: content-box;
-        top: 4px;
-        left: 4px;
-        right: 4px;
-        width: 8px;
-        height: 8px;
+        width: 50%;
+        height: 50%;
         border-radius: 50%;
         background-color: var(--paper-radio-button-checked-color, --primary-color);
         -webkit-transform: scale(0);
@@ -133,6 +132,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       #radioLabel {
+        line-height: normal;
         position: relative;
         display: inline-block;
         vertical-align: middle;
@@ -142,7 +142,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       :host-context([dir="rtl"]) #radioLabel {
-        margin-left: 0px;
+        margin-left: 0;
         margin-right: var(--paper-radio-button-label-spacing, 10px);
       }
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -21,9 +21,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../paper-radio-button.html">
 
+  <style is="custom-style">
+    paper-radio-button.large {
+      --paper-radio-button-size: 48px;
+    }
+    paper-radio-button.medium {
+      --paper-radio-button-size: 24px;
+    }
+    paper-radio-button.small {
+      --paper-radio-button-size: 12px;
+    }
+  </style>
 </head>
 <body>
-
   <test-fixture id="NoLabel">
     <template>
       <paper-radio-button id="radio1"></paper-radio-button>
@@ -39,6 +49,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="AriaLabel">
     <template>
       <paper-radio-button aria-label="Batman">Robin</paper-radio-button>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="WithDifferentSizes">
+    <template>
+      <paper-radio-button class="small" checked></paper-radio-button>
+      <paper-radio-button class="medium" checked></paper-radio-button>
+      <paper-radio-button class="large" checked></paper-radio-button>
     </template>
   </test-fixture>
 
@@ -80,6 +98,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         }, 1);
       });
+
+      test('can be styled with different sizes', function() {
+        var r2 = fixture('WithDifferentSizes');
+        var small = r2[0].getBoundingClientRect();
+        var medium = r2[1].getBoundingClientRect();
+        var large = r2[2].getBoundingClientRect();
+
+        console.log(small.width, medium.width, large.width);
+
+        assert.isTrue(4 < small.height);
+        assert.isTrue(small.height < medium.height);
+        assert.isTrue(medium.height < large.height);
+        assert.isTrue(large.height < 72);
+
+        assert.isTrue(4 < small.width);
+        assert.isTrue(small.width < medium.width);
+        assert.isTrue(medium.width < large.width);
+        assert.isTrue(large.width < 72);
+      });
     });
 
     suite('a11y', function() {
@@ -99,7 +136,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('button with no label has no aria label', function() {
         assert.isTrue(!r1.getAttribute('aria-label'));
       });
-      
+
       test('button respects the user set aria-label', function() {
         var c = fixture('AriaLabel');
         assert.isTrue(c.getAttribute('aria-label') == "Batman");


### PR DESCRIPTION
New pull request for #76, but this time with the correct `<iron-flex-layout>` dependency added. It should not longer look cray cray when it's on its own with no other styling.
