### PR TITLE
Fixes checked rendering issues when used with CSS columns

### DIFF
--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -121,6 +121,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         transform: scale(0);
         transition: -webkit-transform ease 0.28s;
         transition: transform ease 0.28s;
+        will-change: transform;
       }
 
       :host([checked]) #offRadio {


### PR DESCRIPTION
The checked radio div disappears after it's done animating. We use radio buttons in CSS columns and it looks like this is a weird Chrome rendering bug.

See https://github.com/GoogleChrome/ioweb2016/issues/438

https://cloud.githubusercontent.com/assets/1749548/13891915/7aa1c61e-ed2a-11e5-83ec-c58291f4a313.png

R: @bicknellr @notwaldorf 

I've verified this fixes the issue. Generally, it's a good thing to will-change :) Alternatively, we'd need a css custom property hook to set a `z-index` on `#onRadio` 
