### PR TITLE
Use scale instead of pixels, fixes #38

### DIFF
--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -95,26 +95,23 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         color: var(--paper-radio-button-checked-ink-color, --primary-color);
       }
 
-      #offRadio {
+      #offRadio, #onRadio {
         position: absolute;
         box-sizing: border-box;
         top: 0;
         left: 0;
-        right: 0;
         width: 100%;
         height: 100%;
         border-radius: 50%;
-        border: solid 2px;
+      }
+
+      #offRadio {
+        border: 2px solid var(--paper-radio-button-unchecked-color, --primary-text-color);
         background-color: var(--paper-radio-button-unchecked-background-color, transparent);
-        border-color: var(--paper-radio-button-unchecked-color, --primary-text-color);
         transition: border-color 0.28s;
       }
 
       #onRadio {
-        box-sizing: content-box;
-        width: 50%;
-        height: 50%;
-        border-radius: 50%;
         background-color: var(--paper-radio-button-checked-color, --primary-color);
         -webkit-transform: scale(0);
         transform: scale(0);
@@ -128,8 +125,8 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       :host([checked]) #onRadio {
-        -webkit-transform: scale(1);
-        transform: scale(1);
+        -webkit-transform: scale(0.5);
+        transform: scale(0.5);
       }
 
       #radioLabel {


### PR DESCRIPTION
:eyes:
- [x] Zoom: 100% after and before this PR:
  <img width="169" alt="screen shot 2016-03-29 at 21 57 43" src="https://cloud.githubusercontent.com/assets/692644/14122563/a24bbf64-f5fc-11e5-9cba-20df89c642b5.png">
- [x] Zoom: 90% after and before this PR:
  <img width="155" alt="screen shot 2016-03-29 at 21 57 33" src="https://cloud.githubusercontent.com/assets/692644/14122593/b76d313e-f5fc-11e5-9d9e-cf2338e7a4eb.png">
