### PR TITLE
Add --paper-radio-button-checked-border-color

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -68,10 +68,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             --paper-radio-button-unchecked-ink-color: var(--paper-green-900);
             --paper-radio-button-label-color: var(--paper-green-500);
           }
+          paper-radio-button.grey-border {
+            --paper-radio-button-checked-border-color: var(--paper-grey-900);
+            --paper-radio-button-unchecked-color: var(--paper-grey-900);
+          }
         </style>
 
         <paper-radio-button class="red">Radio</paper-radio-button>
         <paper-radio-button checked class="green">Radio</paper-radio-button>
+        <paper-radio-button checked class="grey-border">Radio</paper-radio-button>
       </template>
     </demo-snippet>
   </div>

--- a/paper-radio-button.html
+++ b/paper-radio-button.html
@@ -38,6 +38,7 @@ Custom property | Description | Default
 `--paper-radio-button-unchecked-color` | Radio button color when the input is not checked | `--primary-text-color`
 `--paper-radio-button-unchecked-ink-color` | Selected/focus ripple color when the input is not checked | `--primary-text-color`
 `--paper-radio-button-checked-color` | Radio button color when the input is checked | `--primary-color`
+`--paper-radio-button-checked-border-color` | Radio button border color when the input is checked | `--paper-radio-button-checked-color`
 `--paper-radio-button-checked-ink-color` | Selected/focus ripple color when the input is checked | `--primary-color`
 `--paper-radio-button-size` | Size of the radio button | `16px`
 `--paper-radio-button-label-color` | Label color | `--primary-text-color`
@@ -62,6 +63,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         cursor: pointer;
         @apply(--paper-font-common-base);
         --calculated-paper-radio-button-size: var(--paper-radio-button-size, 16px);
+        --calculated-paper-radio-button-checked-color: var(--paper-radio-button-checked-color, --primary-color);
       }
 
       :host(:focus) {
@@ -112,7 +114,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       #onRadio {
-        background-color: var(--paper-radio-button-checked-color, --primary-color);
+        background-color: var(--calculated-paper-radio-button-checked-color);
         -webkit-transform: scale(0);
         transform: scale(0);
         transition: -webkit-transform ease 0.28s;
@@ -121,7 +123,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       :host([checked]) #offRadio {
-        border-color: var(--paper-radio-button-checked-color, --primary-color);
+        border-color: var(--paper-radio-button-checked-border-color, --calculated-paper-radio-button-checked-color);
       }
 
       :host([checked]) #onRadio {


### PR DESCRIPTION
I added the ability to change the border color of the checked radio independently of the background color.

Previously, they were tied together by --paper-radio-button-checked-color, so I added --paper-radio-button-checked-border-color.

I did not add a test, since it seems that there are no style-based tests, but I did verify that it works and does not break the existing styling behavior.