### PR TITLE
Fix #134 allow positioning inside label by default

### DIFF
--- a/paper-radio-button.js
+++ b/paper-radio-button.js
@@ -141,7 +141,6 @@ Polymer({
 
       #radioLabel {
         line-height: normal;
-        position: relative;
         display: inline-block;
         vertical-align: middle;
         margin-left: var(--paper-radio-button-label-spacing, 10px);


### PR DESCRIPTION
This PR removes an unnecessary default on the label slot.