### PR TITLE
Add support for radio buttons based on a slot

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -20,6 +20,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script type="module">
     import '@polymer/iron-demo-helpers/demo-snippet.js';
     import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
+    import '@polymer/iron-icon/iron-icon.js';
+    import '@polymer/iron-icons/iron-icons.js';
     import '../paper-radio-button.js';
 
     import {html} from '@polymer/polymer/lib/utils/html-tag.js';
@@ -82,6 +84,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         <paper-radio-button class="red">Radio</paper-radio-button>
         <paper-radio-button checked class="green">Radio</paper-radio-button>
+      </template>
+    </demo-snippet>
+
+    <h3>Radio buttons can additionally be a series of icons</h3>
+    <demo-snippet class="centered-demo">
+      <template>
+        <paper-radio-button icon>
+          <span slot="icon">
+            <iron-icon icon="search"></iron-icon>
+          </span>
+        </paper-radio-button>
+        <paper-radio-button icon>
+          <span slot="icon">
+            <iron-icon icon="announcement"></iron-icon>
+          </span>
+          Feedback Mode
+        </paper-radio-button>
       </template>
     </demo-snippet>
   </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -90,6 +90,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h3>Radio buttons can additionally be a series of icons</h3>
     <demo-snippet class="centered-demo">
       <template>
+        <style>
+          /* When the element is in 'icon' mode rather than classic radio buttons,
+           * change styles
+           */
+          paper-radio-button[icon]::part(#radioContainer) {
+            width: 24px;
+            height: 24px;
+          }
+          paper-radio-button[icon]::part(#offRadio),
+          paper-radio-button[icon]::part(#onRadio) {
+            transition: color ease 0.28s;
+          }
+          paper-radio-button[icon]::part(#offRadio) {
+            border: none;
+            background-color: initial;
+            transition: initial;
+          }
+          paper-radio-button[icon]::part(#onRadio) {
+            background-color: initial;
+            -webkit-transform: initial;
+            transform: initial;
+            transition: initial;
+            will-change: initial;
+          }
+          paper-radio-button[icon][checked]::part(#offRadio) {
+            border-color: initial;
+            color: var(--paper-radio-button-checked-color, var(--primary-color));
+          }
+          paper-radio-button[icon][checked]::part(#onRadio) {
+            -webkit-transform: initial;
+            transform: initial;
+            background-color: initial;
+            color: var(--paper-radio-button-unchecked-color, var(--primary-text-color));
+          }
+        </style>
         <paper-radio-button icon>
           <span slot="icon">
             <iron-icon icon="search"></iron-icon>

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,6 +223,38 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
+    "@polymer/iron-icon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-icon/-/iron-icon-3.0.1.tgz",
+      "integrity": "sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==",
+      "dev": true,
+      "requires": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-meta": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-icons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-icons/-/iron-icons-3.0.1.tgz",
+      "integrity": "sha512-xtEI8erH2GIBiF3QxEMyW81XuVjguu6Le5WjEEpX67qd9z7jjmc4T/ke3zRUlnDydex9p8ytcwVpMIKcyvjYAQ==",
+      "dev": true,
+      "requires": {
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/iron-iconset-svg": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-iconset-svg": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz",
+      "integrity": "sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==",
+      "dev": true,
+      "requires": {
+        "@polymer/iron-meta": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "@polymer/iron-location": {
       "version": "3.0.0-pre.26",
       "resolved": "https://registry.npmjs.org/@polymer/iron-location/-/iron-location-3.0.0-pre.26.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "@polymer/iron-test-helpers": "^3.0.0-pre.26",
     "wct-browser-legacy": "^1.0.1",
     "@webcomponents/webcomponentsjs": "^2.0.0",
-    "@polymer/gen-typescript-declarations": "^1.5.1"
+    "@polymer/gen-typescript-declarations": "^1.5.1",
+    "@polymer/iron-icons": "^3.0.1"
   },
   "scripts": {
     "format": "webmat",

--- a/paper-radio-button.js
+++ b/paper-radio-button.js
@@ -185,51 +185,6 @@ Polymer({
         /* slightly darker than the button, so that it's readable */
         opacity: 0.65;
       }
-
-      /* When the element is in 'icon' mode rather than classic radio buttons,
-       * change styles
-       */
-      :host([icon]) #radioContainer {
-        width: 24px;
-        height: 24px;
-      }
-
-      :host([icon]) #offRadio, :host([icon]) #onRadio {
-        transition: color ease 0.28s;
-      }
-
-      :host([icon]) #offRadio {
-        border: none;
-        background-color: initial;
-        transition: initial;
-      }
-
-      :host([icon]) #onRadio {
-        background-color: initial;
-        -webkit-transform: initial;
-        transform: initial;
-        transition: initial;
-        will-change: initial;
-      }
-
-      :host([icon][checked]) #offRadio {
-        border-color: initial;
-        color: var(--paper-radio-button-checked-color, var(--primary-color));
-      }
-
-      :host([icon][checked]) #onRadio {
-        -webkit-transform: initial;
-        transform: initial;
-      }
-
-      :host([icon][checked]) #offRadio {
-        border-color: initial;
-      }
-
-      :host([icon][checked]) #onRadio {
-        background-color: initial;
-        color: var(--paper-radio-button-unchecked-color, var(--primary-text-color));
-      }
     </style>
 
     <div id="radioContainer">

--- a/paper-radio-button.js
+++ b/paper-radio-button.js
@@ -30,6 +30,11 @@ Example:
 
     <paper-radio-button></paper-radio-button>
     <paper-radio-button>Item label</paper-radio-button>
+    <paper-radio-button icon>
+      <span slot="icon">
+        <iron-icon icon="search"></iron-icon>
+      </span>
+    </paper-radio-button>
 
 ### Styling
 
@@ -180,10 +185,57 @@ Polymer({
         /* slightly darker than the button, so that it's readable */
         opacity: 0.65;
       }
+
+      /* When the element is in 'icon' mode rather than classic radio buttons,
+       * change styles
+       */
+      :host([icon]) #radioContainer {
+        width: 24px;
+        height: 24px;
+      }
+
+      :host([icon]) #offRadio, :host([icon]) #onRadio {
+        transition: color ease 0.28s;
+      }
+
+      :host([icon]) #offRadio {
+        border: none;
+        background-color: initial;
+        transition: initial;
+      }
+
+      :host([icon]) #onRadio {
+        background-color: initial;
+        -webkit-transform: initial;
+        transform: initial;
+        transition: initial;
+        will-change: initial;
+      }
+
+      :host([icon][checked]) #offRadio {
+        border-color: initial;
+        color: var(--paper-radio-button-checked-color, var(--primary-color));
+      }
+
+      :host([icon][checked]) #onRadio {
+        -webkit-transform: initial;
+        transform: initial;
+      }
+
+      :host([icon][checked]) #offRadio {
+        border-color: initial;
+      }
+
+      :host([icon][checked]) #onRadio {
+        background-color: initial;
+        color: var(--paper-radio-button-unchecked-color, var(--primary-text-color));
+      }
     </style>
 
     <div id="radioContainer">
-      <div id="offRadio"></div>
+      <div id="offRadio">
+        <slot name="icon"></slot>
+      </div>
       <div id="onRadio"></div>
     </div>
 


### PR DESCRIPTION
For a [smart home sample project](https://github.com/actions-on-google/smart-home-frontend) we want to have several exclusive options for a given smart home state backed by icons. Rather than writing our own radio-group element we'd like to use the existing radio-group and radio-button elements. This change adds an optional `icon` attribute and `icon` slot to the element which transforms the regular empty/filled buttons into a colorful icon.

See the updated demo for the design.

![image](https://user-images.githubusercontent.com/3291635/76887081-18c20280-6858-11ea-8ae4-ff78b119b42d.png)

@proppy